### PR TITLE
57 schemas duplicados

### DIFF
--- a/src/backend/server/controllers/movement-types/movement-types.controller.ts
+++ b/src/backend/server/controllers/movement-types/movement-types.controller.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-useless-catch */
-import { MovementNameEnum, MovementTypeEnum } from '@prisma/client'
-import { MovementType } from '../../../../shared/schemas/movement-type.type'
+import { MovementNameEnum, MovementType, MovementTypeEnum } from '@prisma/client'
 import { prisma } from '../../prisma-client/prisma-client'
 
 const getMovementsTypes = async () => {

--- a/src/backend/server/controllers/movements-details/movement-details.controller.ts
+++ b/src/backend/server/controllers/movements-details/movement-details.controller.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-catch */
-import { MovementDetails } from '../../../../shared/schemas/movement-details.type'
+import { MovementDetails } from '@prisma/client'
 import { prisma } from '../../../server/prisma-client/prisma-client'
 
 const getMovementsDetails = async () => {

--- a/src/backend/server/controllers/movements/movements.controller.ts
+++ b/src/backend/server/controllers/movements/movements.controller.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-catch */
-import { Movement } from '../../../../shared/schemas/movement.type'
+import { Movement } from '@prisma/client'
 import { prisma } from '../../../server/prisma-client/prisma-client'
 
 const getMovements = async () => {

--- a/src/backend/server/controllers/products/products.controller.ts
+++ b/src/backend/server/controllers/products/products.controller.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-useless-catch */
-import { CategoryEnum } from '@prisma/client'
-import { Product } from '../../../../shared/schemas/product.type'
-import { Stock } from '../../../../shared/schemas/stock.type'
+import { CategoryEnum, Product, Stock } from '@prisma/client'
 import { prisma } from '../../../server/prisma-client/prisma-client'
 import {
   createStock,

--- a/src/backend/server/controllers/stocks/stock.controller.ts
+++ b/src/backend/server/controllers/stocks/stock.controller.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-catch */
-import { Stock } from '../../../../shared/schemas/stock.type'
+import { Stock } from '@prisma/client'
 import { prisma } from '../../../server/prisma-client/prisma-client'
 
 const getStocks = async () => {

--- a/src/backend/server/controllers/stores/stores.controller.ts
+++ b/src/backend/server/controllers/stores/stores.controller.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-catch */
-import { Store } from '../../../../shared/schemas/store.type'
+import { Store } from '@prisma/client'
 import { prisma } from '../../../server/prisma-client/prisma-client'
 
 const getStores = async () => {

--- a/src/frontend/@types/frontend.types.ts
+++ b/src/frontend/@types/frontend.types.ts
@@ -1,5 +1,5 @@
+import { Product } from '@prisma/client'
 import { Dispatch } from 'react'
-import { Product } from '../../shared/schemas/product.type'
 
 export type TableProps = {
   products: Product[]

--- a/src/frontend/@types/frontend.types.ts
+++ b/src/frontend/@types/frontend.types.ts
@@ -1,11 +1,5 @@
-import { Product } from '@prisma/client'
+import { Product, Stock, Store } from '@prisma/client'
 import { Dispatch } from 'react'
-<<<<<<< HEAD
-=======
-import { Product } from '../../shared/schemas/product.type'
-import { Stock } from '../../shared/schemas/stock.type'
-import { Store } from '../../shared/schemas/store.type'
->>>>>>> master
 
 export type TableProps = {
   products: Product[]

--- a/src/frontend/components/NavBar.tsx
+++ b/src/frontend/components/NavBar.tsx
@@ -1,6 +1,6 @@
+import { Button } from 'primereact/button'
 import { Menubar } from 'primereact/menubar'
 import { useRouter } from 'next/router'
-import { Button } from 'primereact/button'
 
 const NavBar = () => {
   const router = useRouter()

--- a/src/frontend/components/products/DialogNewProduct.tsx
+++ b/src/frontend/components/products/DialogNewProduct.tsx
@@ -1,10 +1,10 @@
-import { Dialog } from 'primereact/dialog'
-import { InputText } from 'primereact/inputtext'
-import { Dropdown } from 'primereact/dropdown'
 import React, { useState } from 'react'
-import { DialogNewProductProps } from '../../@types/frontend.types'
-import useDialogNewProductMutation from '../../hooks/products/useDialogNewProductMutation'
 import { CategoryEnum } from '@prisma/client'
+import { Dialog } from 'primereact/dialog'
+import { Dropdown } from 'primereact/dropdown'
+import { DialogNewProductProps } from '../../@types/frontend.types'
+import { InputText } from 'primereact/inputtext'
+import useDialogNewProductMutation from '../../hooks/products/useDialogNewProductMutation'
 
 import DialogFooter from './DialogFooter'
 

--- a/src/frontend/components/products/DialogNewProduct.tsx
+++ b/src/frontend/components/products/DialogNewProduct.tsx
@@ -1,19 +1,10 @@
-import React, { useState } from 'react'
-import { CategoryEnum } from '@prisma/client'
-import { Dialog } from 'primereact/dialog'
-import { Dropdown } from 'primereact/dropdown'
-<<<<<<< HEAD
-=======
 import React from 'react'
->>>>>>> master
+import { Dialog } from 'primereact/dialog'
+import DialogFooter from './DialogFooter'
+import { Dropdown } from 'primereact/dropdown'
 import { DialogNewProductProps } from '../../@types/frontend.types'
 import { InputText } from 'primereact/inputtext'
 import useDialogNewProductMutation from '../../hooks/products/useDialogNewProductMutation'
-<<<<<<< HEAD
-
-=======
->>>>>>> master
-import DialogFooter from './DialogFooter'
 
 const DialogNewProduct = ({
   displayBasic,
@@ -40,22 +31,39 @@ const DialogNewProduct = ({
         <div className="field-form-container">
           <div>
             <label htmlFor="id">Nombre</label>
-            <InputText {...productName} name="productName" placeholder='nombre'/>
+            <InputText
+              {...productName}
+              name="productName"
+              placeholder="nombre"
+            />
           </div>
           <div>
             <label htmlFor="id">Descripción</label>
-            <InputText {...productDescription} name="productDescription" placeholder='descripción'/>
+            <InputText
+              {...productDescription}
+              name="productDescription"
+              placeholder="descripción"
+            />
           </div>
           <div>
             <label htmlFor="id">Precio</label>
-            <InputText {...productPrice} name="productPrice" placeholder='precio'/>
+            <InputText
+              {...productPrice}
+              name="productPrice"
+              placeholder="precio"
+            />
           </div>
           {/* COMIENZAN LOS DROPS */}
         </div>
-        <div className='field-drop'>
-          <div className='field-drop'>
+        <div className="field-drop">
+          <div className="field-drop">
             <label htmlFor="id">Categoría</label>
-            <Dropdown value={category} options={CATEGORIES} onChange={(e) => setCategory(e.value)} placeholder={'select category'}/>
+            <Dropdown
+              value={category}
+              options={CATEGORIES}
+              onChange={(e) => setCategory(e.value)}
+              placeholder={'select category'}
+            />
           </div>
         </div>
       </div>

--- a/src/frontend/components/products/DialogUpdateProduct.tsx
+++ b/src/frontend/components/products/DialogUpdateProduct.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
-import { Dialog } from 'primereact/dialog'
-import { InputText } from 'primereact/inputtext'
-import { Dropdown } from 'primereact/dropdown'
-import useDialogUpdateProductMutation from '../../hooks/products/useDialogUpdateProductMutation'
 import { Button } from 'primereact/button'
+import { Dialog } from 'primereact/dialog'
+import { Dropdown } from 'primereact/dropdown'
+import { InputText } from 'primereact/inputtext'
+import useDialogUpdateProductMutation from '../../hooks/products/useDialogUpdateProductMutation'
 
 const DialogUpdateProduct = () => {
   const {

--- a/src/frontend/components/products/ProductsTable.tsx
+++ b/src/frontend/components/products/ProductsTable.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react'
-import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
-import NumberFormat from 'react-number-format'
-
-import { TableProps } from '../../@types/frontend.types'
-import TableHeader from './TableHeader'
-import SelectBodyTemplate from './SelectBodyTemplate'
+import { DataTable } from 'primereact/datatable'
 import DialogNewProduct from './DialogNewProduct'
 import DialogUpdateProduct from './DialogUpdateProduct'
 import DialogError from './DialogError'
+import NumberFormat from 'react-number-format'
+import { TableProps } from '../../@types/frontend.types'
+import TableHeader from './TableHeader'
+import SelectBodyTemplate from './SelectBodyTemplate'
+
 const ProductsTable = ({ products }: TableProps) => {
   const [displayBasic, setDisplayBasic] = useState(false)
   return (

--- a/src/frontend/components/stock/DialogNewStock.tsx
+++ b/src/frontend/components/stock/DialogNewStock.tsx
@@ -1,10 +1,10 @@
-import { Store } from '@prisma/client'
+import React from 'react'
 import { Dialog } from 'primereact/dialog'
 import { Dropdown } from 'primereact/dropdown'
-import { InputText } from 'primereact/inputtext'
-import React from 'react'
 import { DialogNewStockProps } from '../../@types/frontend.types'
+import { InputText } from 'primereact/inputtext'
 import useDialogNewStockMutation from '../../hooks/stock/useDialogNewStockMutation'
+import { Store } from '@prisma/client'
 import StockDialogFooter from './StockDialogFooter'
 
 const DialogNewStock = ({ displayBasic, closeDialog }:DialogNewStockProps) => {

--- a/src/frontend/components/stock/DialogUpdateStock.tsx
+++ b/src/frontend/components/stock/DialogUpdateStock.tsx
@@ -1,9 +1,9 @@
+import React from 'react'
 import { Button } from 'primereact/button'
 import { Dialog } from 'primereact/dialog'
 import { Dropdown } from 'primereact/dropdown'
 import { InputText } from 'primereact/inputtext'
-import React from 'react'
-import { Store } from '../../../shared/schemas/store.type'
+import { Store } from '@prisma/client'
 import useDialogUpdateStockMutation from '../../hooks/stock/useDialogUpdateStockMutation'
 
 const DialogUpdateStock = () => {

--- a/src/frontend/components/stock/StockCheckedBodyTemplate.tsx
+++ b/src/frontend/components/stock/StockCheckedBodyTemplate.tsx
@@ -1,9 +1,9 @@
-import { Checkbox } from 'primereact/checkbox'
 import React from 'react'
-import { useRecoilState } from 'recoil'
-import { StockCheckedBodyTemplateProps } from '../../@types/frontend.types'
-import { isStockCheckedState } from '../../atoms/isStockSelectedAtom'
+import { Checkbox } from 'primereact/checkbox'
 import { defaultStock, selectedStockState } from '../../atoms/selectedStockAtom'
+import { isStockCheckedState } from '../../atoms/isStockSelectedAtom'
+import { StockCheckedBodyTemplateProps } from '../../@types/frontend.types'
+import { useRecoilState } from 'recoil'
 
 const StockCheckedBodyTemplate = ({ rowData }:StockCheckedBodyTemplateProps) => {
   const [, setSelectedStock] = useRecoilState(selectedStockState)

--- a/src/frontend/components/stock/StockDialogFooter.tsx
+++ b/src/frontend/components/stock/StockDialogFooter.tsx
@@ -1,5 +1,5 @@
-import { Button } from 'primereact/button'
 import React from 'react'
+import { Button } from 'primereact/button'
 import { StockDialogFooterProps } from '../../@types/frontend.types'
 
 const StockDialogFooter = ({ closeDialog, handleCreateNewStock }:StockDialogFooterProps) => {

--- a/src/frontend/components/stock/StockTable.tsx
+++ b/src/frontend/components/stock/StockTable.tsx
@@ -1,16 +1,16 @@
+import React, { useState } from 'react'
 import { Column } from 'primereact/column'
 import { DataTable } from 'primereact/datatable'
-import React, { useState } from 'react'
-import { StockTableProps } from '../../@types/frontend.types'
-import useProductsQuery from '../../hooks/products/useProductsQuery'
-import useStoresQuery from '../../hooks/stores/useStoresQuery'
-import { findProductName } from '../../services/products/findProductName'
-import { findStoreName } from '../../services/stores/findStoreName'
 import DialogError from '../products/DialogError'
 import DialogNewStock from './DialogNewStock'
 import DialogUpdateStock from './DialogUpdateStock'
+import { findProductName } from '../../services/products/findProductName'
+import { findStoreName } from '../../services/stores/findStoreName'
+import { StockTableProps } from '../../@types/frontend.types'
 import StockCheckedBodyTemplate from './StockCheckedBodyTemplate'
 import StockTableHeader from './StockTableHeader'
+import useProductsQuery from '../../hooks/products/useProductsQuery'
+import useStoresQuery from '../../hooks/stores/useStoresQuery'
 
 const StockTable = ({ stocks }: StockTableProps) => {
   const [displayBasic, setDisplayBasic] = useState(false)
@@ -49,7 +49,9 @@ const StockTable = ({ stocks }: StockTableProps) => {
           <Column
             field="ProductName"
             header="ProductName"
-            body={(rowData) => findProductName(rowData.productId, productsQuery)}
+            body={(rowData) =>
+              findProductName(rowData.productId, productsQuery)
+            }
             alignHeader={'center'}
           />
           <Column

--- a/src/frontend/components/stock/StockTableHeader.tsx
+++ b/src/frontend/components/stock/StockTableHeader.tsx
@@ -1,13 +1,13 @@
+import React from 'react'
 import { Button } from 'primereact/button'
 import { InputText } from 'primereact/inputtext'
-import React from 'react'
-import { useRecoilState } from 'recoil'
-import { StockTableHeaderProps } from '../../@types/frontend.types'
-import { globalFilterValueState } from '../../atoms/globalFilterValueAtom'
 import { isStockCheckedState } from '../../atoms/isStockSelectedAtom'
+import { globalFilterValueState } from '../../atoms/globalFilterValueAtom'
+import { StockTableHeaderProps } from '../../@types/frontend.types'
 import { showErrorDialogState } from '../../atoms/showErrorDialog'
 import { showUpdateDialogState } from '../../atoms/showUpdateDialogAtom'
 import useDeleteStockMutation from '../../hooks/stock/useDeleteStockMutation'
+import { useRecoilState } from 'recoil'
 
 const StockTableHeader = ({ setDisplayBasic }:StockTableHeaderProps) => {
   const [globalFilterValue, setGlobalFilterValue] = useRecoilState(

--- a/src/frontend/components/store/DialogNewStore.tsx
+++ b/src/frontend/components/store/DialogNewStore.tsx
@@ -1,7 +1,7 @@
-import { Dialog } from 'primereact/dialog'
-import { InputText } from 'primereact/inputtext'
 import React from 'react'
+import { Dialog } from 'primereact/dialog'
 import { DialogNewStoreProps } from '../../@types/frontend.types'
+import { InputText } from 'primereact/inputtext'
 import useDialogNewStoreMutation from '../../hooks/stores/useDialogNewStoreMutation'
 import StoreDialogFooter from './StoreDialogFooter'
 

--- a/src/frontend/components/store/DialogUpdateStore.tsx
+++ b/src/frontend/components/store/DialogUpdateStore.tsx
@@ -1,7 +1,7 @@
+import React from 'react'
 import { Button } from 'primereact/button'
 import { Dialog } from 'primereact/dialog'
 import { InputText } from 'primereact/inputtext'
-import React from 'react'
 import useDialogUpdateStoreMutation from '../../hooks/stores/useDialogUpdateStoreMutation'
 
 const DialogUpdateStore = () => {

--- a/src/frontend/components/store/StoreCheckedBodyTemplate.tsx
+++ b/src/frontend/components/store/StoreCheckedBodyTemplate.tsx
@@ -1,9 +1,9 @@
-import { Checkbox } from 'primereact/checkbox'
 import React from 'react'
-import { useRecoilState } from 'recoil'
-import { StoreCheckedBodyTemplateProps } from '../../@types/frontend.types'
-import { isStoreCheckedState } from '../../atoms/isStoreCheckedAtom'
+import { Checkbox } from 'primereact/checkbox'
 import { defaultStore, selectedStoreState } from '../../atoms/selectedStoreAtom'
+import { isStoreCheckedState } from '../../atoms/isStoreCheckedAtom'
+import { StoreCheckedBodyTemplateProps } from '../../@types/frontend.types'
+import { useRecoilState } from 'recoil'
 
 const StoreCheckedBodyTemplate = ({ rowData }:StoreCheckedBodyTemplateProps) => {
   const [, setSelectedStore] = useRecoilState(selectedStoreState)

--- a/src/frontend/components/store/StoreDialogFooter.tsx
+++ b/src/frontend/components/store/StoreDialogFooter.tsx
@@ -1,5 +1,5 @@
-import { Button } from 'primereact/button'
 import React from 'react'
+import { Button } from 'primereact/button'
 import { StoreDialogFooterProps } from '../../@types/frontend.types'
 
 const StoreDialogFooter = ({

--- a/src/frontend/components/store/StoreTableHeader.tsx
+++ b/src/frontend/components/store/StoreTableHeader.tsx
@@ -1,13 +1,13 @@
+import React from 'react'
 import { Button } from 'primereact/button'
 import { InputText } from 'primereact/inputtext'
-import React from 'react'
-import { useRecoilState } from 'recoil'
-import { TableHeaderProps } from '../../@types/frontend.types'
-import { globalFilterValueState } from '../../atoms/globalFilterValueAtom'
 import { isStoreCheckedState } from '../../atoms/isStoreCheckedAtom'
+import { globalFilterValueState } from '../../atoms/globalFilterValueAtom'
 import { showErrorDialogState } from '../../atoms/showErrorDialog'
 import { showUpdateDialogState } from '../../atoms/showUpdateDialogAtom'
+import { TableHeaderProps } from '../../@types/frontend.types'
 import useDeleteStoreMutation from '../../hooks/stores/useDeleteStoreMutation'
+import { useRecoilState } from 'recoil'
 
 const StoreTableHeader = ({ setDisplayBasic }:TableHeaderProps) => {
   const [globalFilterValue, setGlobalFilterValue] = useRecoilState(

--- a/src/frontend/components/store/StoresTable.tsx
+++ b/src/frontend/components/store/StoresTable.tsx
@@ -1,10 +1,10 @@
+import React, { useState } from 'react'
 import { Column } from 'primereact/column'
 import { DataTable } from 'primereact/datatable'
-import React, { useState } from 'react'
-import { StoresTableProps } from '../../@types/frontend.types'
 import DialogError from '../products/DialogError'
 import DialogNewStore from './DialogNewStore'
 import DialogUpdateStore from './DialogUpdateStore'
+import { StoresTableProps } from '../../@types/frontend.types'
 import StoreCheckedBodyTemplate from './StoreCheckedBodyTemplate'
 import StoreTableHeader from './StoreTableHeader'
 

--- a/src/frontend/hooks/products/useDialogUpdateProductMutation.tsx
+++ b/src/frontend/hooks/products/useDialogUpdateProductMutation.tsx
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { useRecoilState } from 'recoil'
-import { Product } from '../../../shared/schemas/product.type'
-import { CategoryEnum } from '@prisma/client'
+import { CategoryEnum, Product } from '@prisma/client'
 import {
   defaultProductChecked,
   isProductCheckedState
@@ -22,9 +21,8 @@ const useDialogUpdateProductMutation = (queryId: string) => {
   const [showUpdateDialog, setShowUpdateDialog] = useRecoilState(
     showUpdateDialogState
   )
-  const [showErrorDialog, setShowErrorDialog] = useRecoilState(
-    showErrorDialogState
-  )
+  const [showErrorDialog, setShowErrorDialog] =
+    useRecoilState(showErrorDialogState)
   // eslint-disable-next-line no-unused-vars
   const [, setIsProductChecked] = useRecoilState(isProductCheckedState)
   const productName = useField({ initialValue: '', type: 'text' })
@@ -48,7 +46,13 @@ const useDialogUpdateProductMutation = (queryId: string) => {
     }
   })
   const handleUpdateProduct = () => {
-    mutate({ id: selectedProduct.id, name: productName.value as string, description: productDescription.value as string, category: productCategory.value as CategoryEnum, price: productPrice.value as number })
+    mutate({
+      id: selectedProduct.id,
+      name: productName.value as string,
+      description: productDescription.value as string,
+      category: productCategory.value as CategoryEnum,
+      price: productPrice.value as number
+    })
   }
   useEffect(() => {
     productName.onChange(selectedProduct.name)

--- a/src/frontend/hooks/products/useDialogUpdateProductMutation.tsx
+++ b/src/frontend/hooks/products/useDialogUpdateProductMutation.tsx
@@ -50,11 +50,7 @@ const useDialogUpdateProductMutation = (queryId: string) => {
       id: selectedProduct.id,
       name: productName.value as string,
       description: productDescription.value as string,
-<<<<<<< HEAD
-      category: productCategory.value as CategoryEnum,
-=======
       category: productCategory as CategoryEnum,
->>>>>>> master
       price: productPrice.value as number
     })
   }

--- a/src/frontend/hooks/stock/useDialogUpdateStockMutation.tsx
+++ b/src/frontend/hooks/stock/useDialogUpdateStockMutation.tsx
@@ -1,7 +1,7 @@
+import { Store } from '@prisma/client'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { useRecoilState } from 'recoil'
-import { Store } from '../../../shared/schemas/store.type'
 import { StockUpdateData } from '../../@types/frontend.types'
 import {
   defaultStockChecked,

--- a/src/frontend/hooks/stores/useDialogUpdateStoreMutation.tsx
+++ b/src/frontend/hooks/stores/useDialogUpdateStoreMutation.tsx
@@ -1,7 +1,7 @@
+import { Store } from '@prisma/client'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { useRecoilState } from 'recoil'
-import { Store } from '../../../shared/schemas/store.type'
 import {
   defaultStoreChecked,
   isStoreCheckedState

--- a/src/frontend/services/filterProducts.ts
+++ b/src/frontend/services/filterProducts.ts
@@ -1,4 +1,4 @@
-import { Product } from '../../shared/schemas/product.type'
+import { Product } from '@prisma/client'
 
 export const filterProducts = (products: Product[], search: string) => {
   return products?.filter((product) => {

--- a/src/frontend/services/products/filterProducts.ts
+++ b/src/frontend/services/products/filterProducts.ts
@@ -1,8 +1,4 @@
-<<<<<<< HEAD:src/frontend/services/filterProducts.ts
 import { Product } from '@prisma/client'
-=======
-import { Product } from '../../../shared/schemas/product.type'
->>>>>>> master:src/frontend/services/products/filterProducts.ts
 
 export const filterProducts = (products: Product[], search: string) => {
   return products?.filter((product) => {

--- a/src/frontend/services/products/findProductName.ts
+++ b/src/frontend/services/products/findProductName.ts
@@ -1,5 +1,5 @@
+import { Product } from '@prisma/client'
 import { UseQueryResult } from '@tanstack/react-query'
-import { Product } from '../../../shared/schemas/product.type'
 
 export const findProductName = (
   id: string,

--- a/src/frontend/services/products/updateProduct.ts
+++ b/src/frontend/services/products/updateProduct.ts
@@ -1,10 +1,5 @@
-<<<<<<< HEAD:src/frontend/services/updateProduct.ts
 import { Product } from '@prisma/client'
-import publicAxiosInstance from '../api/axios-api'
-=======
-import { Product } from '../../../shared/schemas/product.type'
 import publicAxiosInstance from '../../api/axios-api'
->>>>>>> master:src/frontend/services/products/updateProduct.ts
 
 export const updateProduct = async ({ id, name, price, description, category }: Product) => {
   const response = await publicAxiosInstance.put(`/products/${id}`, {

--- a/src/frontend/services/stock/filterStocks.ts
+++ b/src/frontend/services/stock/filterStocks.ts
@@ -1,4 +1,4 @@
-import { Stock } from '../../../shared/schemas/stock.type'
+import { Stock } from "@prisma/client"
 
 export const filterStocks = (stores: Stock[], quantity: number) => {
   return stores?.filter((stock) => {

--- a/src/frontend/services/stock/filterStocks.ts
+++ b/src/frontend/services/stock/filterStocks.ts
@@ -1,4 +1,4 @@
-import { Stock } from "@prisma/client"
+import { Stock } from '@prisma/client'
 
 export const filterStocks = (stores: Stock[], quantity: number) => {
   return stores?.filter((stock) => {

--- a/src/frontend/services/stores/filterStores.ts
+++ b/src/frontend/services/stores/filterStores.ts
@@ -1,4 +1,4 @@
-import { Store } from "@prisma/client"
+import { Store } from '@prisma/client'
 
 export const filterStores = (stores: Store[], search: string) => {
   return stores?.filter((store) => {

--- a/src/frontend/services/stores/filterStores.ts
+++ b/src/frontend/services/stores/filterStores.ts
@@ -1,4 +1,4 @@
-import { Store } from '../../../shared/schemas/store.type'
+import { Store } from "@prisma/client"
 
 export const filterStores = (stores: Store[], search: string) => {
   return stores?.filter((store) => {

--- a/src/frontend/services/stores/updateStore.ts
+++ b/src/frontend/services/stores/updateStore.ts
@@ -1,4 +1,4 @@
-import { Store } from '../../../shared/schemas/store.type'
+import { Store } from '@prisma/client'
 import publicAxiosInstance from '../../api/axios-api'
 
 export const updateStore = async ({ id, name, address }: Store) => {

--- a/src/frontend/services/updateProduct.ts
+++ b/src/frontend/services/updateProduct.ts
@@ -1,4 +1,4 @@
-import { Product } from '../../shared/schemas/product.type'
+import { Product } from '@prisma/client'
 import publicAxiosInstance from '../api/axios-api'
 
 export const updateProduct = async ({ id, name, price, description, category }: Product) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { RecoilRoot } from 'recoil'
 import NavBar from '../frontend/components/NavBar'
+
 function MyApp ({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient())
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import CardComponent from '../frontend/components/dashboard/Card'
 import BarChartDemo from '../frontend/components/dashboard/Graph'
 import { Card } from 'primereact/card'
+
 const Home: NextPage = () => {
   return (
     <div>

--- a/src/pages/stock.tsx
+++ b/src/pages/stock.tsx
@@ -5,6 +5,7 @@ import { globalFilterValueState } from '../frontend/atoms/globalFilterValueAtom'
 import StockTable from '../frontend/components/stock/StockTable'
 import useStocksQuery from '../frontend/hooks/stock/useStocksQuery'
 import { filterStocks } from '../frontend/services/stock/filterStocks'
+
 const Stock: NextPage = () => {
   const query = useStocksQuery('stocks')
   const [globalFilterValue] = useRecoilState(globalFilterValueState)

--- a/src/pages/stores.tsx
+++ b/src/pages/stores.tsx
@@ -5,6 +5,7 @@ import { globalFilterValueState } from '../frontend/atoms/globalFilterValueAtom'
 import StoresTable from '../frontend/components/store/StoresTable'
 import useStoresQuery from '../frontend/hooks/stores/useStoresQuery'
 import { filterStores } from '../frontend/services/stores/filterStores'
+
 const Stores: NextPage = () => {
   const query = useStoresQuery('stores')
   const [globalFilterValue] = useRecoilState(globalFilterValueState)

--- a/src/shared/schemas/movement-details.type.ts
+++ b/src/shared/schemas/movement-details.type.ts
@@ -1,6 +1,0 @@
-export type MovementDetails = {
-  id: string
-  productId: string
-  movementId: string
-  quantity:number
-}

--- a/src/shared/schemas/movement-type.type.ts
+++ b/src/shared/schemas/movement-type.type.ts
@@ -1,8 +1,0 @@
-import { MovementNameEnum, MovementTypeEnum } from '@prisma/client'
-
-export type MovementType = {
-  id: string
-  movementType: MovementTypeEnum
-  movementName: MovementNameEnum
-  cause: string
-}

--- a/src/shared/schemas/movement.type.ts
+++ b/src/shared/schemas/movement.type.ts
@@ -1,6 +1,0 @@
-export type Movement = {
-  id: string
-  datetime: Date
-  observation: string
-  movementTypeId: string
-}

--- a/src/shared/schemas/product.type.ts
+++ b/src/shared/schemas/product.type.ts
@@ -1,9 +1,0 @@
-import { CategoryEnum } from '@prisma/client'
-
-export type Product = {
-  id: string
-  name: string
-  price: number
-  description: string,
-  category: CategoryEnum
-}

--- a/src/shared/schemas/stock.type.ts
+++ b/src/shared/schemas/stock.type.ts
@@ -1,7 +1,0 @@
-export type Stock = {
-  id: string
-  productId: string
-  storeId: string
-  quantity: number
-  minQuantity: number
-}

--- a/src/shared/schemas/store.type.ts
+++ b/src/shared/schemas/store.type.ts
@@ -1,5 +1,0 @@
-export type Store = {
-    id: string
-    name: string
-    address: string
-}


### PR DESCRIPTION
Solicito la review de los 3 para que, si estan de acuerdo se mergea esto, sino, lo dejamos como estaba (no es de vida o muerte).

Explico, lo que hice fue lo siguiente: 
- Todos los tipos de datos compartidos entre frontend y backend, pueden solicitarse de UN SOLO ARCHIVO en la ubicacion:
`'node_modules/.prisma/client/index.d.ts'`
- Por ello, elimine los tipos compartidos en la carpeta: `'src/shared/schemas' `, dejando solamente el tipo PingResponse que no es propio de prisma

Ahora bien, ventajas y desventajas que veo de esto:
:heavy_check_mark:  Ventajas: No tenemos que tener 2 veces, en el mismo proyecto, el mismo tipo de dato. No repetimos codigo innecesario, y, si no me equivoco, esto también va a colaborar a la performance del sistema en su totalidad

:negative_squared_cross_mark: Desventajas: Tanto el frontend como el backend tendrán que solicitar el tipado de datos en este archivo que mencioné (`'node_modules/.prisma/client/index.d.ts'`), por favor, metanse en la rama, y entren en ese archivo así ven la "complejidad" que tiene el mismo. Si bien lo unico que vamos a hacer es usar el tipo de dato que se exporte ahí, tal vez consideran que es mucho quilombo ir a buscar el dato hasta ahí y prefieren tenerlo en la carpeta shared/schemas como antes.

:question: En base a esto, decidan que les parece, que prefieren o que les gusta más y  sean libres de mergear o no esto. 
:rocket: