### PR TITLE
added sending productId to the server on Stock Update

### DIFF
--- a/src/frontend/@types/frontend.types.ts
+++ b/src/frontend/@types/frontend.types.ts
@@ -63,6 +63,7 @@ export type StockUpdateData = {
   storeId: string
   quantity: number
   minQuantity: number
+  productId: string
 }
 
 export type StockTableProps = { stocks: Stock[] }

--- a/src/frontend/hooks/stock/useDialogUpdateStockMutation.tsx
+++ b/src/frontend/hooks/stock/useDialogUpdateStockMutation.tsx
@@ -38,8 +38,10 @@ const useDialogUpdateStockMutation = (queryId: string) => {
     id,
     storeId,
     quantity,
-    minQuantity
-  }: StockUpdateData) => updateStock({ id, storeId, quantity, minQuantity })
+    minQuantity,
+    productId
+  }: StockUpdateData) =>
+    updateStock({ id, storeId, quantity, minQuantity, productId })
   const { mutate } = useMutation(updateQuery, {
     onSuccess: () => {
       // Invalidate and refetch
@@ -67,7 +69,8 @@ const useDialogUpdateStockMutation = (queryId: string) => {
       id: selectedStock.id,
       storeId: selectedStore.id as string,
       quantity: quantity.value as number,
-      minQuantity: minQuantity.value as number
+      minQuantity: minQuantity.value as number,
+      productId: selectedStock.productId
     })
   }
   const changeStore = (name: string) => {

--- a/src/frontend/services/stock/updateStock.ts
+++ b/src/frontend/services/stock/updateStock.ts
@@ -3,6 +3,7 @@ import publicAxiosInstance from '../../api/axios-api'
 
 export const updateStock = async ({
   id,
+  productId,
   storeId,
   quantity,
   minQuantity
@@ -10,7 +11,8 @@ export const updateStock = async ({
   const response = await publicAxiosInstance.put(`/stock/${id}`, {
     storeId,
     quantity,
-    minQuantity
+    minQuantity,
+    productId
   })
   return response
 }


### PR DESCRIPTION
- Se manda el ProductId al momento de realizar una actualizacion de un registro de Stock

@nhussein11 lo que te decia yo es que no hacia falta que te lo mande, si con el StockId podes buscar el producto y el Store al cual referencia antes de acatualizar el registro
- buscabas el Stock con el id que viene en la URL
- con ese registro traidas ProductId y StoreId
- chequeabas si el "nuevo Stock" ya existia etc...